### PR TITLE
土地保護pluginなどと干渉する問題を解決

### DIFF
--- a/src/Deceitya/MiningLevel/Event/EventListener.php
+++ b/src/Deceitya/MiningLevel/Event/EventListener.php
@@ -31,7 +31,7 @@ class EventListener implements Listener
     }
 
     /**
-     * @priority HIGH
+     * @priority MONITOR
      * @ignoreCancelled
      */
     public function onBlockBreak(BlockBreakEvent $event)


### PR DESCRIPTION
Economy_Landなどの土地保護pliuginにおいてイベントの発火順序により保護していても壊せばレベルが増えてしまう点を改善しました。